### PR TITLE
Fixed missing 'alt' attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Easy JAIL for ExpressionEngine
 ==============================
 
-ExpressionEngine Plugin to automate use of the jQuery Asynchronous Image Loader
+ExpressionEngine Plugin to automate use of the jQuery Asynchronous Image Loader.
+
+This fork keeps the content of the 'alt' attribute when images are replaced which is important if you want to have WCAG 2.0 compliant code.
 
 The API
 -------

--- a/system/expressionengine/third_party/easy_jail/pi.easy_jail.php
+++ b/system/expressionengine/third_party/easy_jail/pi.easy_jail.php
@@ -8,6 +8,9 @@
  This extension was created by Aaron Gustafson
  - aaron@easy-designs.net
  This work is licensed under the MIT License.
+
+ This version modified by Jens Korff, Creative Spirits
+
 =====================================================
  File: pi.easy_jail.php
 -----------------------------------------------------
@@ -81,6 +84,7 @@ class Easy_jail {
 		$lookup = '/(<img([^>]*)\/?>)/';
 		if ( preg_match_all( $lookup, $str, $found, PREG_SET_ORDER ) )
 		{
+
 			# loop the matches
 			foreach ( $found as $instance )
 			{
@@ -94,25 +98,33 @@ class Easy_jail {
 				if ( substr( $instance[2], -1, 1 ) == '/' )
 				{
 					$instance[2] = substr( $instance[2], 0, -1 );
-				} 
+				}
 
-				foreach ( explode( ' ', trim( $instance[2] ) ) as $attr )
-				{
-					preg_match_all( '/([^=]*)=([\'"])(.*)\\2$/', $attr, $matches, PREG_SET_ORDER );
-					
-					if ( isset( $matches[0] ) )
-					{
-						if ( $matches[0][1] == 'src' )
-						{
-							$src = $matches[0][3];
-						}
-						else
-						{
-							$attributes[$matches[0][1]] = $matches[0][1] . '="' . $matches[0][3] . '"';
+				# Get delimiter of "alt" attribute (as this is the critical one [can contain " or ' inside text])
+				preg_match('/alt=([\'"])/', $instance[2], $matches);
+				$delimiter = $matches[1];
+
+				# Get all attributes
+				# Reference: http://stackoverflow.com/questions/138313/how-to-extract-img-src-title-and-alt-from-html-using-php#answer-2937682
+				$doc = new DOMDocument();
+				@$doc->loadHTML($o_img);
+				$tags = $doc->getElementsByTagName('img');
+
+				foreach ($tags as $tag) {
+				#       echo $tag->getAttribute('src');
+
+					foreach ($tag->attributes as $attribute) {
+						$name = $attribute->name;
+						$value = $attribute->value;
+
+						if ( $name == 'src' ) {
+							$src = $value;
+						} else {
+							$attributes[$name] = $name . '=' . $delimiter . $value . $delimiter;
 						}
 					}
 				}
-				
+
 				# enforce an alt attribute
 				if ( ! isset( $attributes['alt'] ) )
 				{


### PR DESCRIPTION
When using the original plugin I noticed that 'alt' attribute content was not carried over.

Good alternative content of images is important to sites which want to be WCAG 2.0 compliant and accessible to visitors with visual disabilities.

I noticed that the problem was in the regex, especially if there were more than one spaces before the 'alt' attribute. 

After a bit of research I decided to replace the regex with DOMDocument() which makes it much easier to extract tags and their attributes.
